### PR TITLE
Fx dupicate windows

### DIFF
--- a/src/main/java/com/idealupdater/utils/ui/SystemTrayUtils.java
+++ b/src/main/java/com/idealupdater/utils/ui/SystemTrayUtils.java
@@ -2,7 +2,9 @@ package com.idealupdater.utils.ui;
 
 import com.idealupdater.utils.structlog4j.LoggerFactory;
 import com.idealupdater.utils.structlog4j.interfaces.Logger;
+import com.idealupdater.utils.ui.controllers.UpdateViewController;
 import com.idealupdater.utils.utils.Prefs;
+import javafx.application.Platform;
 
 import java.awt.*;
 import java.awt.event.*;
@@ -141,7 +143,7 @@ public class SystemTrayUtils {
             public void actionPerformed(ActionEvent e) {
                 try {
                     Prefs.getInstance().setSideBarTargetBtn("status");
-                    new UpdateView().launch();
+                    launchUpdateView("status");
                 } catch (Exception ex) {
                     logger.error(LOG_TAG, "event", "open_status_view",
                             "custom_message", ex.getMessage());
@@ -153,8 +155,9 @@ public class SystemTrayUtils {
             public void actionPerformed(ActionEvent e) {
                 try {
                     Prefs.getInstance().setSideBarTargetBtn("settings");
-                    new UpdateView().launch();
+                    launchUpdateView("settings");
                 } catch (Exception ex) {
+                    ex.printStackTrace();
                     logger.error(LOG_TAG, "event", "open_status_view",
                             "custom_message", ex.getMessage());
                 }
@@ -192,7 +195,7 @@ public class SystemTrayUtils {
             public void actionPerformed(ActionEvent ev) {
                 try {
                     Prefs.getInstance().setSideBarTargetBtn("client");
-                    new UpdateView().launch();
+                    launchUpdateView("client");
                 } catch (Exception ex) {
                     logger.error(LOG_TAG, "event", "open_client_update_view",
                             "custom_message", ex.getMessage());
@@ -249,8 +252,9 @@ public class SystemTrayUtils {
             public void actionPerformed(ActionEvent ev) {
                 try {
                     Prefs.getInstance().setSideBarTargetBtn("server");
-                    new UpdateView().launch();
+                    launchUpdateView("server");
                 } catch (Exception ex) {
+                    ex.printStackTrace();
                     logger.error(LOG_TAG, "event", "open_client_log_directory",
                             "custom_message", ex.getMessage());
                 }
@@ -335,6 +339,14 @@ public class SystemTrayUtils {
 
         trayIcon.displayMessage("Sun TrayIcon Demo",
                 message, messageType);
+    }
+
+    public static void launchUpdateView(String action){
+        if( UpdateViewController.instance == null){
+            new UpdateView().launch();
+        }else {
+            UpdateViewController.instance.fireBtnEvent(action);
+        }
     }
 
 }

--- a/src/main/java/com/idealupdater/utils/ui/UpdateView.java
+++ b/src/main/java/com/idealupdater/utils/ui/UpdateView.java
@@ -3,13 +3,17 @@ package com.idealupdater.utils.ui;
 import com.idealupdater.utils.structlog4j.LoggerFactory;
 import com.idealupdater.utils.structlog4j.interfaces.Logger;
 import com.idealupdater.utils.ui.controllers.UpdateViewController;
+import com.idealupdater.utils.utils.Prefs;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
 
 import javax.swing.*;
+import java.util.Optional;
 
 public class UpdateView {
     public static final Logger logger = LoggerFactory.getLogger(SystemTrayUtils.class);
@@ -18,8 +22,8 @@ public class UpdateView {
     public void launch(){
         JFrame window = new JFrame();
         JFXPanel jfxPanel = new JFXPanel();
-        Platform.runLater(() -> {
 
+        Platform.runLater(() -> {
             try {
                 FXMLLoader loader = new FXMLLoader(getClass().getResource("/views/UpdateView.fxml"));
                 Parent root = loader.load();
@@ -31,11 +35,17 @@ public class UpdateView {
                     window.setLocationRelativeTo(null); // centers the window
                     window.setVisible(true);
                 });
-
             } catch (Exception e) {
                 logger.error(LOG_TAG, "event", "show main window", "custom_message", e.getMessage());
             }
+        });
 
+        /* JFrame on close action */
+        window.addWindowListener(new java.awt.event.WindowAdapter() {
+            @Override
+            public void windowClosing(java.awt.event.WindowEvent windowEvent) {
+                UpdateViewController.instance = null;
+            }
         });
     }
 

--- a/src/main/java/com/idealupdater/utils/ui/controllers/UpdateViewController.java
+++ b/src/main/java/com/idealupdater/utils/ui/controllers/UpdateViewController.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.ResourceBundle;
 
 public class UpdateViewController implements Initializable {
+    public static UpdateViewController instance;
     public static final Logger logger = LoggerFactory.getLogger(SystemTrayUtils.class);
     public static final String LOG_TAG = "CheckUpdate";
     @FXML public JFXButton statusBtn, clientUpdateBtn, serverUpdateBtn, settingsBtn, updateBtn;
@@ -39,6 +40,7 @@ public class UpdateViewController implements Initializable {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        instance = this;
         logger.info(LOG_TAG, "event", "updateView controller", "message",
                 "initialize updateView controller");
         // the sidebar buttons array list allows one to set specific button active while the rest remain inactive
@@ -141,6 +143,7 @@ public class UpdateViewController implements Initializable {
         Platform.runLater(() -> {
             for (JFXButton button : sidebarBtns) {
                 if (button.getText().toLowerCase().contains(targetName)) {
+                    // this simulates the action event when fired
                     button.fire();
                 }
             }

--- a/src/main/java/com/idealupdater/utils/utils/Prefs.java
+++ b/src/main/java/com/idealupdater/utils/utils/Prefs.java
@@ -64,7 +64,6 @@ public class Prefs {
     public void setRemoteClientPath(String target) {
         prefs.put("RemoteClientPath", target);
     }
-
 }
 
 

--- a/src/main/resources/styles/updateView.css
+++ b/src/main/resources/styles/updateView.css
@@ -49,14 +49,21 @@
     -fx-fill: white;
 }
 
-/* content */
-.content{
+/* content pane*/
+.contentPane{
     -fx-background-color:  #17344f;
 }
 
 /* update button */
 .updateBtn{
     -fx-background-color: -fx-purple;
+    -fx-text-fill: white;
+    -fx-font-weight: bold;
+    -fx-font-size: 15px;
+}
+
+.revertBtn{
+    -fx-background-color: -fx-blue;
     -fx-text-fill: white;
     -fx-font-weight: bold;
     -fx-font-size: 15px;
@@ -75,3 +82,15 @@
 .jfx-progress-bar > .bar {
     -fx-background-color: orange;
 }
+
+.console {
+    -fx-font-family: Consolas;
+    -fx-font-size: 15;
+    -fx-text-fill: #ffffff;
+    -fx-display-caret:true;
+}
+
+.console .content{
+      -fx-background-color: black;
+      -fx-fill: white;
+  }

--- a/src/main/resources/views/UpdateView.fxml
+++ b/src/main/resources/views/UpdateView.fxml
@@ -6,6 +6,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.TextArea?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
@@ -38,9 +39,9 @@
             </JFXButton>
          </children>
       </VBox>
-      <AnchorPane layoutX="163.0" prefHeight="623.0" prefWidth="614.0" style="-fx-background-color: #fbfbfb;" styleClass="content" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="163.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+      <AnchorPane layoutX="163.0" prefHeight="623.0" prefWidth="614.0" style="-fx-background-color: #fbfbfb;" styleClass="contentPane" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="163.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>
-            <AnchorPane fx:id="headerAnchorPane" layoutX="56.0" minHeight="-Infinity" prefHeight="70.0" prefWidth="566.0" styleClass="content" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+            <AnchorPane fx:id="headerAnchorPane" layoutX="56.0" minHeight="-Infinity" prefHeight="70.0" prefWidth="566.0" styleClass="contentPane" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                <children>
                   <Label fx:id="headerLabel" layoutY="18.0" prefHeight="70.0" text="Client Updates" textFill="WHITE" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                      <font>
@@ -65,7 +66,7 @@
                   <Insets top="100.0" />
                </padding>
             </AnchorPane>
-            <AnchorPane fx:id="updatesAnchorPane" layoutX="50.0" layoutY="92.0" visible="false" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="92.0">
+            <AnchorPane fx:id="updatesAnchorPane" layoutX="50.0" layoutY="92.0" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="92.0">
                <children>
                   <Label layoutY="43.0" text="New Features" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="20.0">
                      <font>
@@ -76,7 +77,7 @@
                     <content>
                       <AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="546.0">
                            <children>
-                              <VBox prefHeight="182.0" prefWidth="614.0" spacing="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+                              <VBox fx:id="featureVBox" prefHeight="182.0" prefWidth="614.0" spacing="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
                                  <children>
                                     <Label fx:id="versionLabel" text="V1.0.1">
                                        <font>
@@ -104,8 +105,21 @@
                         </AnchorPane>
                     </content>
                   </ScrollPane>
-                  <JFXButton fx:id="updateBtn" layoutY="304.0" prefHeight="44.0" prefWidth="185.0" styleClass="updateBtn" text="UPDATE" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="280.0" />
-                  <AnchorPane layoutY="366.0" prefHeight="148.0" styleClass="consolePane" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="366.0" />
+                  <JFXButton fx:id="updateBtn" layoutY="304.0" onAction="#performUpdate" prefHeight="44.0" prefWidth="185.0" styleClass="updateBtn" text="UPDATE" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="280.0" />
+                  <TextArea fx:id="consoleField" editable="false" prefHeight="200.0" styleClass="console" text="Console Output!" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="366.0" />
+                  <ScrollPane layoutX="10.0" layoutY="93.0" prefHeight="200.0" prefWidth="200.0" style="-fx-background-color: transparent;" visible="false" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="366.0">
+                     <content>
+                        <AnchorPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="546.0" />
+                     </content>
+                  </ScrollPane>
+                  <JFXButton fx:id="revertBtn" layoutX="10.0" layoutY="314.0" onAction="#performRevert" prefHeight="44.0" styleClass="revertBtn" text="BACK TO OLD VERSION" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="280.0">
+                     <padding>
+                        <Insets left="20.0" right="20.0" />
+                     </padding>
+                     <graphic>
+                        <FontAwesomeIconView fill="WHITE" glyphName="ARROW_LEFT" />
+                     </graphic>
+                  </JFXButton>
                </children>
             </AnchorPane>
             <AnchorPane fx:id="noUpdatesAnchorPane" visible="false" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="92.0">


### PR DESCRIPTION
## WHAT
 - created dynamic display for the new features vbox using labels
 - changed the console view anchor pane to text area
 - added binding for the command prompt execution with the text area for display as command is being executed
 - added styling to the updates console text area
 - added a revert updates button
 - adjusted display of controls during the perform update process
 - added an launchUpdateView method in the SystemsTrayUtils class
 - added a class instance attribute to the UpdateViewController.java class
 - added close event handler for the update view that nullifies the UpdateViewController class instance

## WHY
 - to display the any amount of new features on the interface
 - the anchor pane could not hold the text hence the textarea with editable feature disabled worked fine
 - the binding helps in displaying the output of the results of the command prompt
 - the revertUpdates button is for going back to the previous version, should appear after the updates have been made
 - the class instance is used to detect if the window was already open
 - the launchUpdateView method detects if the windows was previously opened or not, if so then it just firest the event needed else it opens a new window.

## ADDITIONAL NOTE
 - the command being used for emulating the console output is `ping localhost -n 6`
## SCREENSHOTS
![iup3](https://user-images.githubusercontent.com/27273023/50838923-41a35980-1370-11e9-9631-9f63f83c3dbd.PNG)
