### PR TITLE
Fx server status

### DIFF
--- a/src/main/java/com/idealupdater/utils/ui/controllers/UpdateViewController.java
+++ b/src/main/java/com/idealupdater/utils/ui/controllers/UpdateViewController.java
@@ -115,6 +115,7 @@ public class UpdateViewController implements Initializable {
             // if server is running
             pid = ApplicationUtilities.getProcessIdFromFile(Prefs.getInstance().getLocalServerPath() +
                     "/py-dist/proc.txt");
+
             if (ApplicationUtilities.isProcessIdRunning(pid)) {
                 serverToggleBtn.setSelected(true);
             } else {
@@ -441,7 +442,7 @@ public class UpdateViewController implements Initializable {
                                     toggleBtn.setText("OFF");
                                 }
                             }
-                        }catch(IOException|InterruptedException ex){
+                        }catch(IOException ex){
                             ex.printStackTrace();
                         }
                     }

--- a/src/main/java/com/idealupdater/utils/utils/ApplicationUtilities.java
+++ b/src/main/java/com/idealupdater/utils/utils/ApplicationUtilities.java
@@ -68,10 +68,24 @@ public class ApplicationUtilities {
         }
     }
 
-    public static void killProcessId(String processId) throws IOException, InterruptedException {
-        String KILL = "taskkill /F /T /PID ";
-        if (isProcessRunning(processId)){
-            Runtime.getRuntime().exec(KILL + "\""+processId+"\"");
+    /**
+     * Executes batch file for task kill process.
+     * @param  processId the application process to kill
+     * The bat file is executed with the paramater of the processId
+     *  <pre>
+     *       String processId = 12345;
+     *       Runtime.getRuntime().exec("C:/User/Desktop/killProcessId.bat" +" " +processId);
+     *  </pre>
+     */
+    public static void killProcessId(String processId) throws IOException {
+        if (isProcessIdRunning(processId)){
+            logger.info(LOG_TAG, "event", "checking if process id ["+processId+"] is running",
+                    "command", Prefs.getInstance().getLocalServerPath() +
+                            "/py-dist/killProcessId.bat" +" " +processId);
+
+            Runtime.getRuntime().exec(
+                    Prefs.getInstance().getLocalServerPath() +
+                            "/py-dist/killProcessId.bat" +" " +processId);
         }
     }
 

--- a/src/main/java/com/idealupdater/utils/utils/ApplicationUtilities.java
+++ b/src/main/java/com/idealupdater/utils/utils/ApplicationUtilities.java
@@ -23,6 +23,15 @@ public class ApplicationUtilities {
         }
     }
 
+    public static void runServerApplication(String applicationFilePath, String processId) throws IOException, InterruptedException {
+        // cd into the installation directory and call the exe file
+        String command = "cmd /c \"cd "+applicationFilePath+" && \"ClassicPOS Server.exe\"\"";
+
+        if (!isProcessIdRunning(processId)){
+            Runtime.getRuntime().exec(command);
+        }
+    }
+
     public static boolean isProcessRunning(String processName) throws IOException, InterruptedException {
         ProcessBuilder processBuilder = new ProcessBuilder("tasklist.exe");
         Process process = processBuilder.start();

--- a/src/main/resources/views/UpdateView.fxml
+++ b/src/main/resources/views/UpdateView.fxml
@@ -193,7 +193,7 @@
                   <Insets top="100.0" />
                </padding>
             </AnchorPane>
-            <AnchorPane fx:id="settingsAnchorPane" layoutX="60.0" layoutY="102.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="30.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="92.0">
+            <AnchorPane fx:id="settingsAnchorPane" layoutX="60.0" layoutY="102.0" visible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="30.0" AnchorPane.rightAnchor="20.0" AnchorPane.topAnchor="92.0">
                <children>
                   <JFXButton fx:id="serverBrowseBtn" layoutX="401.0" layoutY="46.0" onAction="#chooseServerDirectory" prefHeight="44.0" prefWidth="92.0" styleClass="updateBtn" text="Browse" AnchorPane.leftAnchor="0.0" />
                   <Label layoutX="10.0" layoutY="7.0" text="Choose the server installation directory:" AnchorPane.leftAnchor="10.0">


### PR DESCRIPTION
## WHAT
 -  added a start and stop thread method in the UpdateViewController
 - added the start thread method to the initialize method
 - refactored checkStatusWithNoEventParam
 - added Platform.runLater fjavax thread to wrap the toggle controls to and avoid fx exception
 - refined the status toggle functionality
 - added the runServerApplication to the ApplicationUtilities
 - adjustment of setting the client path
 - changed the kill process id execution command
 - added code comment for the killProcessId method in AppliactionUtilities.java
 - remove unused exception call in the killProcessId metho

## WHY
 - the stop and start thread help in determining the running the on and off state
 - adding the start thread method to the initialize method ensures that the thread starts running and checking if the status has changed
 - reduced the if else statement in the checkStatusWithNoEventParam method
 - the runServerApplication  is for changing direction to the installation path and then executing the file in that directory
 - adjusted the saveconfig method that saves the configurations to the prefs